### PR TITLE
Reintroduce Charm Store publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,8 +6,8 @@ on:
       - master
 
 jobs:
-  charm:
-    name: Charm
+  ch:
+    name: Charmhub
     runs-on: ubuntu-latest
 
     steps:
@@ -28,3 +28,39 @@ jobs:
         echo "$CHARMCRAFT_CREDENTIALS" > ~/.config/charmcraft.credentials
         charmcraft pack --destructive-mode
         charmcraft upload ./*.charm --release=edge
+  cs:
+    name: Charm Store
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: |
+        set -eux
+        sudo snap install charm --classic
+        sudo pip3 install charmcraft==1.2.1
+        sudo snap install yq
+
+    - name: Publish charm
+      env:
+        CHARMSTORE_CREDENTIAL: ${{ secrets.CHARMSTORE_CREDENTIAL }}
+        CHARMCRAFT_DEVELOPER: 'Y'
+      run: |
+        set -eux
+        echo "$CHARMSTORE_CREDENTIAL" > ~/.go-cookies
+
+        CS_URL="cs:~kubeflow-charmers/kubeflow-volumes"
+
+        IMAGE=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)
+        charmcraft pack --destructive-mode
+        docker pull $IMAGE
+        charm push ./*.charm $CS_URL --resource oci-image=$IMAGE
+
+        REVISION=$(charm show $CS_URL --channel unpublished --format yaml | yq e .id-revision.Revision -)
+        OCI_VERSION=$(charm list-resources $CS_URL --format yaml --channel unpublished | yq e .0.revision -)
+        charm release \
+            --channel edge \
+            --resource oci-image-$OCI_VERSION \
+            $CS_URL-$REVISION


### PR DESCRIPTION
This charm will act as a test charm for "split-brain" publishing, where we get to actually test out publishing to charmhub via charmcraft, but at the expense of also managing keeping the charm store in sync manually instead of relying on the background sync process.