### PR TITLE
fix: force CheckFailed msg arg to string, fix CI

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -18,12 +18,12 @@ from serialized_data_interface import (
 class CheckFailed(Exception):
     """ Raise this exception if one of the checks in main fails. """
 
-    def __init__(self, msg, status_type=None):
+    def __init__(self, msg: str, status_type=None):
         super().__init__()
 
-        self.msg = msg
+        self.msg = str(msg)
         self.status_type = status_type
-        self.status = status_type(msg)
+        self.status = status_type(self.msg)
 
 
 class Operator(CharmBase):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -57,9 +57,9 @@ async def test_build_and_deploy(ops_test):
         timeout=600,
     )
     await ops_test.model.deploy(
-        "cs:kubeflow-dashboard", config={"profile": "kubeflow-user"}
+        "kubeflow-dashboard", config={"profile": "kubeflow-user"}
     )
-    await ops_test.model.deploy("cs:kubeflow-profiles")
+    await ops_test.model.deploy("kubeflow-profiles")
 
     await ops_test.model.add_relation("kubeflow-dashboard", "kubeflow-profiles")
     await ops_test.model.add_relation(


### PR DESCRIPTION
fixes error where non-string input will cause an exception when instantiating the `status`