### PR TITLE
Bump ops to fix relation data race condition

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-ops==1.1.0
+ops==1.2.0
 oci-image==1.0.0
 serialized-data-interface<0.4


### PR DESCRIPTION
Ops<1.2 could have the case where the charm asks for relation data before it was available, resulting in odd failures where relations are established but even the initial data posted to them is not available as expected.