### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -70,6 +70,8 @@ jobs:
 
       - name: Run test
         run: |
+          sg microk8s -c "microk8s enable ingress metallb:10.64.140.43-10.64.140.49"
+          sudo usermod --append --groups lxd $USER
           # Requires the model to be called kubeflow due to this bug:
           # https://github.com/kubeflow/kubeflow/issues/6136
           juju add-model kubeflow

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -63,13 +63,18 @@ jobs:
             provider: microk8s
             channel: 1.21/stable
             charmcraft-channel: latest/candidate
+
+      - name: Configure kubectl
+        run: |
+          sg microk8s -c "microk8s config > ~/.kube/config"
+
       - name: Run test
         run: |
-          sg microk8s -c "microk8s enable ingress metallb:10.64.140.43-10.64.140.49"
-          sudo usermod --append --groups lxd $USER
+          # Requires the model to be called kubeflow due to this bug:
+          # https://github.com/kubeflow/kubeflow/issues/6136
+          juju add-model kubeflow
           sudo apt install -y firefox-geckodriver
-          sudo snap install juju-kubectl --classic
-          sg microk8s -c "tox -e integration"
+          sg microk8s -c "tox -e integration -- --model kubeflow"
 
       - run: sg microk8s -c "microk8s.kubectl get all -A"
         if: failure()

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -6,6 +6,7 @@ summary: Kubeflow Volumes
 description: Kubeflow Volumes
 maintainers: [Juju Developers <juju@lists.ubuntu.com>]
 tags: [ai, bigdata, kubeflow, machine-learning, tensorflow]
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:
@@ -18,4 +19,3 @@ requires:
     interface: ingress
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
     versions: [v1]
-min-juju-version: 2.8.6

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -45,18 +45,18 @@ async def test_build_and_deploy(ops_test):
     )
 
     await ops_test.run(
-            "kubectl",
-            "patch",
-            "role/istio-ingressgateway-operator",
-            "-p",
-            yaml.dump(
-                {
-                    "apiVersion": "rbac.authorization.k8s.io/v1",
-                    "kind": "Role",
-                    "metadata": {"name": "istio-ingressgateway-operator"},
-                    "rules": [{"apiGroups": ["*"], "resources": ["*"], "verbs": ["*"]}],
-                }
-            ),
+        "kubectl",
+        "patch",
+        "role/istio-ingressgateway-operator",
+        "-p",
+        yaml.dump(
+            {
+                "apiVersion": "rbac.authorization.k8s.io/v1",
+                "kind": "Role",
+                "metadata": {"name": "istio-ingressgateway-operator"},
+                "rules": [{"apiGroups": ["*"], "resources": ["*"], "verbs": ["*"]}],
+            }
+        ),
     )
 
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -5,11 +5,11 @@ import logging
 from pathlib import Path
 from random import choices
 from string import ascii_lowercase
-from subprocess import check_output, run
 from time import sleep
 
 import yaml
-
+import lightkube
+from lightkube.resources.core_v1 import Service
 import pytest
 from selenium.common.exceptions import JavascriptException, WebDriverException
 from selenium.webdriver.firefox.options import Options
@@ -24,46 +24,22 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test):
     my_charm = await ops_test.build_charm(".")
-    run(["juju", "switch", ops_test.model_full_name])
-    await ops_test.model.deploy("cs:istio", trust=True)
-    await ops_test.model.applications["istio-pilot"].set_config(
-        {"default-gateway": "kubeflow-gateway"}
-    )
-    sleep(10)
-    run(
-        [
-            "juju",
-            "kubectl",
-            "patch",
-            "role/istio-ingressgateway-operator",
-            "-p",
-            yaml.dump(
-                {
-                    "apiVersion": "rbac.authorization.k8s.io/v1",
-                    "kind": "Role",
-                    "metadata": {"name": "istio-ingressgateway-operator"},
-                    "rules": [{"apiGroups": ["*"], "resources": ["*"], "verbs": ["*"]}],
-                }
-            ),
-        ]
-    )
+    log.info(f"Built charm {my_charm}")
 
-    await ops_test.model.block_until(
-        lambda: all(
-            (unit.workload_status == "active") and unit.agent_status == "idle"
-            for _, application in ops_test.model.applications.items()
-            for unit in application.units
-        ),
-        timeout=600,
+    await ops_test.model.deploy(
+        entity_url="istio-pilot",
+        channel="1.5/stable",
+        config={"default-gateway": "kubeflow-gateway"},
     )
     await ops_test.model.deploy(
-        "kubeflow-dashboard", config={"profile": "kubeflow-user"}
+        entity_url="istio-gateway",
+        application_name="istio-ingressgateway",
+        channel="1.5/stable",
+        trust=True,
     )
-    await ops_test.model.deploy("kubeflow-profiles")
-
-    await ops_test.model.add_relation("kubeflow-dashboard", "kubeflow-profiles")
     await ops_test.model.add_relation(
-        "istio-pilot:ingress", "kubeflow-dashboard:ingress"
+        "istio-pilot:istio-pilot",
+        "istio-ingressgateway:istio-pilot",
     )
 
     await ops_test.model.block_until(
@@ -74,6 +50,31 @@ async def test_build_and_deploy(ops_test):
         ),
         timeout=600,
     )
+
+    await ops_test.model.deploy(
+        entity_url="kubeflow-dashboard",
+        channel="1.4/edge",
+        config={"profile": "kubeflow-user"},
+    )
+    await ops_test.model.deploy(
+        entity_url="kubeflow-profiles",
+        channel="1.4/edge",
+    )
+    await ops_test.model.add_relation("kubeflow-dashboard", "kubeflow-profiles")
+    await ops_test.model.add_relation(
+        "istio-pilot:ingress",
+        "kubeflow-dashboard:ingress",
+    )
+
+    await ops_test.model.block_until(
+        lambda: all(
+            (unit.workload_status == "active") and unit.agent_status == "idle"
+            for _, application in ops_test.model.applications.items()
+            for unit in application.units
+        ),
+        timeout=600,
+    )
+
     image_path = METADATA["resources"]["oci-image"]["upstream-source"]
     resources = {"oci-image": image_path}
     await ops_test.model.deploy(my_charm, resources=resources)
@@ -89,9 +90,14 @@ async def test_status(ops_test):
 
 @pytest.fixture()
 def driver(request, ops_test):
-    status = yaml.safe_load(check_output(["juju", "status", "--format=yaml"]))
-    endpoint = status["applications"]["istio-ingressgateway"]["address"]
+    lightkube_client = lightkube.Client()
+    gateway_svc = lightkube_client.get(
+        Service, "istio-ingressgateway", namespace=ops_test.model_name
+    )
+
+    endpoint = gateway_svc.status.loadBalancer.ingress[0].ip
     url = f"http://{endpoint}.nip.io/_/volumes/?ns=kubeflow-user"
+
     options = Options()
     options.headless = True
     options.log.level = "trace"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -25,7 +25,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 async def test_build_and_deploy(ops_test):
     my_charm = await ops_test.build_charm(".")
     run(["juju", "switch", ops_test.model_full_name])
-    await ops_test.model.deploy("cs:istio")
+    await ops_test.model.deploy("cs:istio", trust=True)
     await ops_test.model.applications["istio-pilot"].set_config(
         {"default-gateway": "kubeflow-gateway"}
     )

--- a/tox.ini
+++ b/tox.ini
@@ -20,11 +20,12 @@ deps =
 
 [testenv:integration]
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     pytest-operator
     selenium
     selenium-wire
+    lightkube<0.11
 commands = pytest -v --tb native --show-capture=no --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration
 
 [testenv:unit]
@@ -35,4 +36,3 @@ commands =
 commands =
     flake8 {toxinidir}/src {toxinidir}/tests
     black --check {toxinidir}/src {toxinidir}/tests
-


### PR DESCRIPTION
Currently, integration test fails to deploy istio due to:
```
juju.errors.JujuError: Bundle cannot be deployed without trusting applications with your cloud credentials.
Please repeat the deploy command with the --trust argument if you consent to trust the following application
 - istio-ingressgateway-operator
 ```
This PR updates the tests, deploying istio `1.5/stable`, adding the `--trust` option and necessary config. The gateway address is now retrieved using lightkube.