### PR TITLE
hack: pin `release-charm` action to dev version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel
-        uses: canonical/charming-actions/release-charm@1.0.3
+        uses: canonical/charming-actions/release-charm@handle-charmcraft-structured-status
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Temporarily pins `release-charm` action pinned to a development version to handle charmhub branches.  See #24  for more information.