### PR TITLE
fix: integration.yaml CI failure

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,6 @@
 # See LICENSE file for licensing details.
 
 black
-flake8
+flake8==4.0.1
 flake8-copyright<0.3
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ deps =
 
 [testenv:integration]
 deps =
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
     pytest-operator
     selenium


### PR DESCRIPTION
This fixes an issue found when previous PR was merged.  See [this CI run](https://github.com/canonical/kubeflow-volumes-operator/pull/32).  That issue was caused because this charm's CI has a pylibjuju dependency pinned to the [juju main branch](https://github.com/juju/python-libjuju) rather than a released package.  There was a change to the main branch sometime recently that breaks this charm (and also breaks [dex](https://github.com/canonical/dex-auth-operator/runs/7560442093?check_suite_focus=true#step:5:1924) and probably others).  Pinning to the released pypi version of Juju fixes the issue

When merging this PR, squash and merge to remove junk commits in the middle
