### PR TITLE
Observe leader-elected event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -37,6 +37,7 @@ class Operator(CharmBase):
             self.on.config_changed,
             self.on.install,
             self.on.upgrade_charm,
+            self.on.leader_elected,
             self.on["ingress"].relation_changed,
         ]:
             self.framework.observe(event, self.main)

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -17,6 +17,12 @@ def test_not_leader(harness):
     assert harness.charm.model.unit.status == WaitingStatus("Waiting for leadership")
 
 
+def test_leader_elected(harness):
+    harness.begin_with_initial_hooks()
+    harness.set_leader(True)
+    assert harness.charm.model.unit.status != WaitingStatus("Waiting for leadership")
+
+
 def test_missing_image(harness):
     harness.set_leader(True)
     harness.begin_with_initial_hooks()


### PR DESCRIPTION
When we use `juju upgrade-charm`, a new non-leader unit gets created, then the old still-leader one gets removed, resulting in the new unit being elected as the leader.
When the `leader_elected` event is not observed, the charm is not aware of having a leader now, so it remains stuck with message 'Waiting for leadership'.
This PR adds a fix to observe this event.