### PR TITLE
feat: dynamic sidebar content

### DIFF
--- a/lib/charms/kubeflow_dashboard/v0/kubeflow_dashboard_sidebar.py
+++ b/lib/charms/kubeflow_dashboard/v0/kubeflow_dashboard_sidebar.py
@@ -1,0 +1,129 @@
+"""# KubeflowDashboardSidebar Library
+This library is designated to ease the process of adding the componentes 
+to the UI sidebar of Kubeflow dashboard. The sidbar is dynamic and allows 
+to add and remove items based on the configmap content.
+
+In order to add an item to the library `sidebar` relation needs to be established
+between the application which is going to be added and the kubeflow dashboard application.
+At the joining event the joning application needs to send a json containing the sidebar element
+details. Charm using this library is expected to provide these details on initialization.
+These details are send through relation data.
+
+These are the required fields:
+- **type**: type of the sidebar element (only `item` option is allowed)
+- **link**: relative path to the place of redirection.
+- **text**: text of the displayed sidebar element
+- **icon**: icon of the sidebar element
+
+Bellow is the example (for tensorboards application) of json body. Remember list of configuration
+is expected so one or many sidebars can be added at the same time:
+```
+{
+    "position": 3,
+    "type": "item",
+    "link": "/tensorboards/",
+    "text": "Tensorboards",
+    "icon": "assessment",
+}
+```
+
+In oder to remove the item from the sidebar `sidebar` relation needs to be removed.
+
+## Getting Started
+
+To get started using the library, you just need to fetch the library using `charmcraft`.
+
+```shell
+cd some-charm
+charmcraft fetch-lib charms.kubeflow_dashboard.v0.kubeflow_dashboard_sidebar
+```
+
+Then, to initialise the library:
+
+```python
+from charms.kubeflow_dashboard.v0.kubeflow_dashboard_sidebar import (
+    KubeflowDashboardSidebar,
+)
+# ...
+
+SIDEBAR_LINK = [
+    {
+        "position": 4,
+        "type": "item",
+        "link": "/tensorboards/",
+        "text": "Tensorboards",
+        "icon": "assessment",
+    }
+] # list of items must be provided
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    self.kubeflow_dashboard_sidebar = KubeflowDashboardSidebar(self, SIDEBAR_LINK)
+    # ...
+```
+"""
+
+import json
+import logging
+
+from typing import Dict
+from ops.charm import CharmBase, RelationJoinedEvent, RelationDepartedEvent
+from ops.framework import Object
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "a5795a88ee31458f9bc3ae026a04b89f"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+class KubeflowDashboardSidebar(Object):
+    def __init__(
+        self,
+        charm: CharmBase,
+        sidebar_link: Dict,
+    ):
+        """Constructor for KubernetesServicePatch.
+
+        Args:
+            charm: the charm that is instantiating the library.
+            sidebar_link: dictionary specifying the elemnt of the sidebar to be added.
+        """
+        super().__init__(charm, None)
+        self.charm = charm
+        self.sidebar_link = sidebar_link
+        self.framework.observe(
+            self.charm.on.sidebar_relation_joined,
+            self._on_sidebar_relation_joined,
+        )
+        self.framework.observe(
+            self.charm.on.sidebar_relation_departed,
+            self._on_sidebar_relation_departed,
+        )
+
+    def _on_sidebar_relation_joined(self, event: RelationJoinedEvent):
+        """Send the confing  on relation joined
+
+        Args:
+            event: relation joined object
+        """
+        if not self.charm.unit.is_leader():
+            return
+        event.relation.data[self.charm.app].update({"config": json.dumps(self.sidebar_link)})
+
+    def _on_sidebar_relation_departed(self, event: RelationDepartedEvent):
+        """Remove the confing  on relation departed
+
+        Args:
+            event: relation departed object
+        """
+        if not self.charm.unit.is_leader():
+            return
+        event.relation.data[self.charm.app].update({"config": json.dumps([])})

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,3 +19,7 @@ requires:
     interface: ingress
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/ingress.yaml
     versions: [v1]
+provides:
+  sidebar:
+    interface: sidebar
+    optional: true

--- a/src/charm.py
+++ b/src/charm.py
@@ -46,6 +46,10 @@ class Operator(CharmBase):
         self.framework.observe(
             self.on.sidebar_relation_joined, self._on_sidebar_relation_joined
         )
+        self.framework.observe(
+            self.on.sidebar_relation_departed,
+            self._on_sidebar_relation_departed,
+        )
 
     def main(self, event):
         try:
@@ -171,6 +175,7 @@ class Operator(CharmBase):
                     [
                         {
                             "app": self.app.name,
+                            "position": 3,
                             "type": "item",
                             "link": "/volumes/",
                             "text": "Volumes",
@@ -180,6 +185,11 @@ class Operator(CharmBase):
                 )
             }
         )
+
+    def _on_sidebar_relation_departed(self, event):
+        if not self.unit.is_leader():
+            return
+        event.relation.data[self.app].update({"config": json.dumps([])})
 
 
 if __name__ == "__main__":

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,7 +23,6 @@ from seleniumwire import webdriver
 log = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
-PROFILE_NAME = "kubeflow-user"
 
 
 @pytest.mark.abort_on_fail
@@ -64,9 +63,7 @@ async def test_relate_dependencies(ops_test: OpsTest):
         "istio-pilot:istio-pilot", "istio-ingressgateway:istio-pilot"
     )
 
-    await ops_test.model.deploy(
-        "kubeflow-dashboard", channel="latest/edge", config={"profile": PROFILE_NAME}
-    )
+    await ops_test.model.deploy("kubeflow-dashboard", channel="latest/edge", trust=True)
     await ops_test.model.deploy(
         "kubeflow-profiles",
         channel="latest/edge",
@@ -93,7 +90,7 @@ def driver(request, ops_test):
     )
 
     endpoint = gateway_svc.status.loadBalancer.ingress[0].ip
-    url = f"http://{endpoint}.nip.io/_/volumes/?ns={PROFILE_NAME}"
+    url = f"http://{endpoint}.nip.io/_/volumes"
 
     options = Options()
     options.headless = True


### PR DESCRIPTION
Related to this [jira task](https://warthogs.atlassian.net/browse/KF-567?atlOrigin=eyJpIjoiN2M3MjQwZmY2NzEwNGQwMTkzYThkZTNhMzU0YmFlNmUiLCJwIjoiaiJ9) and this [feature](https://github.com/canonical/kubeflow-dashboard-operator/issues/8)

In `kubeflow-dashboard-operator` there is a `sidebar` relation. In order to add element to the sidebar proper relation needs to be established. After the relation is set, charms fills the config for given app-name.

Sidebar element is removed after the relation is broken.