### PR TITLE
fix: remove deprecated dashboard config from tests

### DIFF
--- a/tests/integration/profile.yaml
+++ b/tests/integration/profile.yaml
@@ -1,0 +1,11 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+apiVersion: kubeflow.org/v1
+kind: Profile
+metadata:
+  name: profilename
+spec:
+  owner:
+    kind: User
+    name: userid2@email.com

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -82,55 +82,62 @@ async def test_relate_dependencies(ops_test: OpsTest):
     )
 
 
-@pytest.fixture()
-def profile(lightkube_client):
-    """Creates a Profile object in cluster, cleaning it up after"""
-    profile_file = "./tests/integration/profile.yaml"
-    yaml_text = _safe_load_file_to_text(profile_file)
-    yaml_rendered = yaml.safe_load(yaml_text)
-    profilename = yaml_rendered["metadata"]["name"]
+# # Disabled until we re-enable the selenium tests below
+# @pytest.fixture()
+# def profile(lightkube_client):
+#     """Creates a Profile object in cluster, cleaning it up after"""
+#     profile_file = "./tests/integration/profile.yaml"
+#     krh = KubernetesResourceHandler(
+#         field_manager="volumes-ci",
+#         template_files=[profile_file],
+#         context={},
+#     )
+#     # Syntax here might be wrong - needs to be tested when these tests are re-enabled
+#     yaml_rendered = hrh.render_manifests()
+#     profilename = yaml_rendered["metadata"]["name"]
+#
+#     krh.apply()
+#     yield profilename
+#
+#     # TODO: Delete the profile object using the above rendered yaml
 
-    create_all_from_yaml(yaml_file=yaml_text, lightkube_client=lightkube_client)
-    yield profilename
 
-    delete_all_from_yaml(yaml_text, lightkube_client)
-
-
-@pytest.fixture()
-def driver(request, ops_test, profile):
-    profile_name = profile
-    lightkube_client = Client()
-    gateway_svc = lightkube_client.get(
-        Service, "istio-ingressgateway-workload", namespace=ops_test.model_name
-    )
-
-    endpoint = gateway_svc.status.loadBalancer.ingress[0].ip
-    url = f"http://{endpoint}.nip.io/_/volumes/?ns={profile_name}"
-
-    options = Options()
-    options.headless = True
-    options.log.level = "trace"
-
-    kwargs = {
-        "options": options,
-        "seleniumwire_options": {"enable_har": True},
-    }
-
-    with webdriver.Firefox(**kwargs) as driver:
-        wait = WebDriverWait(driver, 15, 1, (JavascriptException, StopIteration))
-        for _ in range(60):
-            try:
-                driver.get(url)
-                break
-            except WebDriverException:
-                sleep(5)
-        else:
-            driver.get(url)
-
-        yield driver, wait, url
-
-        Path(f"/tmp/selenium-{request.node.name}.har").write_text(driver.har)
-        driver.get_screenshot_as_file(f"/tmp/selenium-{request.node.name}.png")
+# Disabled until we re-enable the selenium tests below
+# @pytest.fixture()
+# def driver(request, ops_test, profile):
+#     profile_name = profile
+#     lightkube_client = Client()
+#     gateway_svc = lightkube_client.get(
+#         Service, "istio-ingressgateway-workload", namespace=ops_test.model_name
+#     )
+#
+#     endpoint = gateway_svc.status.loadBalancer.ingress[0].ip
+#     url = f"http://{endpoint}.nip.io/_/volumes/?ns={profile_name}"
+#
+#     options = Options()
+#     options.headless = True
+#     options.log.level = "trace"
+#
+#     kwargs = {
+#         "options": options,
+#         "seleniumwire_options": {"enable_har": True},
+#     }
+#
+#     with webdriver.Firefox(**kwargs) as driver:
+#         wait = WebDriverWait(driver, 15, 1, (JavascriptException, StopIteration))
+#         for _ in range(60):
+#             try:
+#                 driver.get(url)
+#                 break
+#             except WebDriverException:
+#                 sleep(5)
+#         else:
+#             driver.get(url)
+#
+#         yield driver, wait, url
+#
+#         Path(f"/tmp/selenium-{request.node.name}.har").write_text(driver.har)
+#         driver.get_screenshot_as_file(f"/tmp/selenium-{request.node.name}.png")
 
 
 # TODO: Reenable tests - Temporarily disabled.  They work locally, but not in CI

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -7,18 +7,19 @@ from pathlib import Path
 # from random import choices
 # from string import ascii_lowercase
 # from subprocess import check_output
-from time import sleep
+# from time import sleep
 
 import yaml
 
-from lightkube import Client
-from lightkube.resources.core_v1 import Service
+# from lightkube import Client
+# from lightkube.resources.core_v1 import Service
 import pytest
 from pytest_operator.plugin import OpsTest
-from selenium.common.exceptions import JavascriptException, WebDriverException
-from selenium.webdriver.firefox.options import Options
-from selenium.webdriver.support.ui import WebDriverWait
-from seleniumwire import webdriver
+
+# from selenium.common.exceptions import JavascriptException, WebDriverException
+# from selenium.webdriver.firefox.options import Options
+# from selenium.webdriver.support.ui import WebDriverWait
+# from seleniumwire import webdriver
 
 log = logging.getLogger(__name__)
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -64,9 +64,7 @@ async def test_relate_dependencies(ops_test: OpsTest):
         "istio-pilot:istio-pilot", "istio-ingressgateway:istio-pilot"
     )
 
-    await ops_test.model.deploy(
-        "kubeflow-dashboard", channel="latest/edge", config={"profile": PROFILE_NAME}
-    )
+    await ops_test.model.deploy("kubeflow-dashboard", channel="latest/edge")
     await ops_test.model.deploy(
         "kubeflow-profiles",
         channel="latest/edge",


### PR DESCRIPTION
Removes the profile config option from the deployment of dashboard.  This option has been removed from the dashboard charm
