### PR TITLE
fix: pin ubuntu version, flake8 in track/1.6

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -11,7 +11,7 @@ jobs:
 
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
 
   lint:
     name: Lint Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out code
@@ -39,7 +39,7 @@ jobs:
 
   unit:
     name: Unit Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out code
@@ -53,7 +53,7 @@ jobs:
 
   deploy:
     name: Integration tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-charm-paths:
     name: Generate the Charm Matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   publish-charm:
     name: Publish Charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: get-charm-paths
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,6 +2,8 @@
 # See LICENSE file for licensing details.
 
 black
+# Temporarily pinned to due flake8-copyright not yet supporting flake8 6.  This can be removed when
+# [this fix](https://github.com/savoirfairelinux/flake8-copyright/pull/20) is merged.
 flake8==4.0.1
-flake8-copyright<0.3
+flake8-copyright
 pytest


### PR DESCRIPTION
In track/1.6, this PR pins:
* `runs-on: ubuntu-latest` to avoid getting runners that cannot build our charms
* flake8<6 to mitigate an incompatibility between flake8 6 and the flake8-copyright plugin