### PR TITLE
Remove bcrypt from unittests

### DIFF
--- a/requirements-unit.in
+++ b/requirements-unit.in
@@ -13,7 +13,6 @@
 #     add clarity to the dependency list.
 #   * Pinning a version of a python package/lib shared with requirements.in
 #     must not introduce any incompatibilities.
-bcrypt
 coverage
 ops
 pytest

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -6,8 +6,6 @@
 #
 attrs==23.1.0
     # via jsonschema
-bcrypt==4.0.1
-    # via -r requirements-unit.in
 certifi==2023.7.22
     # via requests
 charset-normalizer==3.2.0


### PR DESCRIPTION
Remove bcrypt package from unit test dependencies.

NOTE: bcrypt is still indirect requirement for juju in integration tests 

Closes https://github.com/canonical/kubeflow-volumes-operator/issues/99