### PR TITLE
ci: update juju to 3.1 and microk8s to 1.25

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -54,10 +54,10 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
           provider: microk8s
-          channel: 1.24/stable
+          channel: 1.25-strict/stable
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
           charmcraft-channel: latest/candidate
-          juju-channel: 2.9/stable
+          juju-channel: 3.1/stable
 
       - name: Run test
         run: |
@@ -66,28 +66,28 @@ jobs:
           # Requires the model to be called kubeflow due to this bug:
           # https://github.com/kubeflow/kubeflow/issues/6136
           juju add-model kubeflow
-          sg microk8s -c "tox -e integration -- --model kubeflow"
+          sg snap_microk8s -c "tox -e integration -- --model kubeflow"
 
-      - run: sg microk8s -c "microk8s.kubectl get all -A"
+      - run: sg snap_microk8s -c "microk8s.kubectl get all -A"
         if: failure()
 
-      - run: sg microk8s -c "microk8s.kubectl get pods -A -oyaml"
+      - run: sg snap_microk8s -c "microk8s.kubectl get pods -A -oyaml"
         if: failure()
 
       - run: juju status
         if: failure()
 
       - name: Get kubeflow-volumes workload logs
-        run: sg microk8s -c "microk8s.kubectl logs --tail 100 -nkubeflow -ljuju-app=kubeflow-volumes"
+        run: sg snap_microk8s -c "microk8s.kubectl logs --tail 100 -nkubeflow -ljuju-app=kubeflow-volumes"
         if: failure()
 
       - name: Get kubeflow-volumes operator logs
-        run: sg microk8s -c "microk8s.kubectl logs --tail 100 -nkubeflow -ljuju-operator=kubeflow-volumes"
+        run: sg snap_microk8s -c "microk8s.kubectl logs --tail 100 -nkubeflow -ljuju-operator=kubeflow-volumes"
         if: failure()
 
       - name: Generate inspect tarball
         run: >
-          sg microk8s <<EOF
+          sg snap_microk8s <<EOF
             microk8s inspect | \
             grep -Po "Report tarball is at \K.+" | \
             xargs -I {} cp {} inspection-report-${{ strategy.job-index }}.tar.gz

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,5 +1,5 @@
-# Pinning to <3.0 to ensure compatibility with the 2.9 controller version
-juju<3.0
+# Pinning to <4.0 due to compatibility with the 3.1 controller version
+juju<4.0
 lightkube
 pytest
 pytest-operator

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -6,7 +6,7 @@
 #
 anyio==4.0.0
     # via httpcore
-asttokens==2.2.1
+asttokens==2.4.0
     # via stack-data
 attrs==23.1.0
     # via
@@ -18,7 +18,7 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.6.2
     # via selenium-wire
-brotli==1.0.9
+brotli==1.1.0
     # via selenium-wire
 cachetools==5.3.1
     # via google-auth
@@ -66,6 +66,8 @@ httpcore==0.17.3
     # via httpx
 httpx==0.24.1
     # via lightkube
+hvac==1.2.1
+    # via juju
 hyperframe==6.0.1
     # via
     #   h2
@@ -86,12 +88,10 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==2.9.44.0
+juju==3.2.2
     # via
     #   -r requirements-integration.in
     #   pytest-operator
-jujubundlelib==0.5.7
-    # via theblues
 kaitaistruct==0.10
     # via selenium-wire
 kubernetes==27.2.0
@@ -101,9 +101,7 @@ lightkube==0.14.0
 lightkube-models==1.28.1.4
     # via lightkube
 macaroonbakery==1.3.1
-    # via
-    #   juju
-    #   theblues
+    # via juju
 markupsafe==2.1.3
     # via jinja2
 matplotlib-inline==0.1.6
@@ -148,6 +146,8 @@ pycparser==2.21
     # via cffi
 pygments==2.16.1
     # via ipython
+pyhcl==0.4.5
+    # via hvac
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -167,7 +167,7 @@ pysocks==1.7.1
     # via
     #   selenium-wire
     #   urllib3
-pytest==7.4.0
+pytest==7.4.2
     # via
     #   -r requirements-integration.in
     #   pytest-asyncio
@@ -178,27 +178,26 @@ pytest-operator==0.29.0
     # via -r requirements-integration.in
 python-dateutil==2.8.2
     # via kubernetes
-pytz==2023.3
+pytz==2023.3.post1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
     #   -r requirements-integration.in
     #   juju
-    #   jujubundlelib
     #   kubernetes
     #   lightkube
     #   pytest-operator
 requests==2.31.0
     # via
+    #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
-    #   theblues
 requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
-selenium==4.11.2
+selenium==4.12.0
     # via
     #   -r requirements-integration.in
     #   selenium-wire
@@ -223,8 +222,6 @@ sortedcontainers==2.4.0
     # via trio
 stack-data==0.6.2
     # via ipython
-theblues==0.5.2
-    # via juju
 tomli==2.0.1
     # via
     #   ipdb
@@ -239,7 +236,7 @@ trio==0.22.2
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.10.3
+trio-websocket==0.10.4
     # via selenium
 typing-extensions==4.7.1
     # via
@@ -254,9 +251,9 @@ urllib3[socks]==2.0.4
     #   selenium
 wcwidth==0.2.6
     # via prompt-toolkit
-websocket-client==1.6.2
+websocket-client==1.6.3
     # via kubernetes
-websockets==7.0
+websockets==8.1
     # via juju
 wsproto==1.2.0
     # via

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -75,7 +75,6 @@ async def test_relate_dependencies(ops_test: OpsTest):
     await ops_test.model.add_relation("istio-pilot:ingress", "kubeflow-dashboard:ingress")
     await ops_test.model.add_relation("istio-pilot", "kubeflow-volumes")
     await ops_test.model.wait_for_idle(
-        wait_for_units=True,
         raise_on_blocked=True,
         raise_on_error=True,
         timeout=300,


### PR DESCRIPTION
- ci: update juju to 3.1 and microk8s to 1.25
- remove `wait_for_units` parameter from the `wait_for_idle` call, due to it being deprecated in pyjuju 3, the method is now set to `wait_for_units` by default when `wait_for_at_least_units` is not set so there's no change in the behavior of the test 