### PR TITLE
Integrate the filebrowser rock into `track/1.8`

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,5 +16,5 @@ options:
     description: Whether cookies should require HTTPS
   volume-viewer-image:
     type: string
-    default: filebrowser/filebrowser:v2.23.0
+    default: charmedkubeflow/filebrowser:2.27.0-f21fe9d
     description: Volume Viewer OCI Image (PVCViewer)


### PR DESCRIPTION
change the filebrowser default image to use our rock from https://github.com/canonical/filebrowser-rock

closes #126 

### Testing instructions

See #126 