### PR TITLE
build: bump juju, ops versions in ci and requirements files

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,7 +57,7 @@ jobs:
           channel: 1.25-strict/stable
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
           charmcraft-channel: latest/candidate
-          juju-channel: 3.1/stable
+          juju-channel: 3.4/stable
 
       - name: Run test
         run: |

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -88,7 +88,7 @@ jedi==0.19.0
     # via ipython
 jinja2==3.1.2
     # via pytest-operator
-juju==3.2.2
+juju==3.4.0.0
     # via
     #   -r requirements-integration.in
     #   pytest-operator
@@ -115,7 +115,9 @@ oauthlib==3.2.2
 outcome==1.2.0
     # via trio
 packaging==23.1
-    # via pytest
+    # via
+    #   juju
+    #   pytest
 paramiko==2.12.0
     # via juju
 parso==0.8.3
@@ -174,7 +176,7 @@ pytest==7.4.2
     #   pytest-operator
 pytest-asyncio==0.21.1
     # via pytest-operator
-pytest-operator==0.29.0
+pytest-operator==0.34.0
     # via -r requirements-integration.in
 python-dateutil==2.8.2
     # via kubernetes

--- a/requirements-unit.in
+++ b/requirements-unit.in
@@ -1,21 +1,8 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-# Please note this file introduces dependencies from the charm's requirements.in,
-# special attention must be taken when updating this or the other .in file to try
-# to avoid incompatibilities.
-# Rules for editing this file:
-#   * Removing a dependency that is no longer used in the unit test file(s)
-#     is allowed, and should not represent any risk.
-#   * Adding a dependency in this file means the dependency is directly used
-#     in the unit test files(s).
-#   * ALL python packages/libs used directly in the unit test file(s) must be
-#     listed here even if requirements.in is already adding them. This will
-#     add clarity to the dependency list.
-#   * Pinning a version of a python package/lib shared with requirements.in
-#     must not introduce any incompatibilities.
 coverage
 ops
 pytest
 pytest-mock
 pytest-lazy-fixture
--r requirements.in
+-r requirements.txt

--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -5,69 +5,102 @@
 #    pip-compile requirements-unit.in
 #
 anyio==4.2.0
-    # via httpx
+    # via
+    #   -r requirements.txt
+    #   httpx
 attrs==23.1.0
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 certifi==2023.7.22
     # via
+    #   -r requirements.txt
     #   httpcore
     #   httpx
     #   requests
 charmed-kubeflow-chisme==0.2.1
-    # via -r requirements.in
+    # via -r requirements.txt
 charset-normalizer==3.2.0
-    # via requests
+    # via
+    #   -r requirements.txt
+    #   requests
 coverage==7.3.0
     # via -r requirements-unit.in
 deepdiff==6.2.1
-    # via charmed-kubeflow-chisme
-exceptiongroup==1.1.3
     # via
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
+exceptiongroup==1.2.0
+    # via
+    #   -r requirements.txt
     #   anyio
     #   pytest
 h11==0.14.0
-    # via httpcore
+    # via
+    #   -r requirements.txt
+    #   httpcore
 httpcore==1.0.2
-    # via httpx
+    # via
+    #   -r requirements.txt
+    #   httpx
 httpx==0.26.0
-    # via lightkube
+    # via
+    #   -r requirements.txt
+    #   lightkube
 idna==3.4
     # via
+    #   -r requirements.txt
     #   anyio
     #   httpx
     #   requests
 importlib-resources==6.0.1
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
-    # via charmed-kubeflow-chisme
+    # via
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
 jsonschema==4.17.3
-    # via serialized-data-interface
+    # via
+    #   -r requirements.txt
+    #   serialized-data-interface
 lightkube==0.15.0
     # via
-    #   -r requirements.in
+    #   -r requirements.txt
     #   charmed-kubeflow-chisme
 lightkube-models==1.29.0.6
-    # via lightkube
+    # via
+    #   -r requirements.txt
+    #   lightkube
 markupsafe==2.1.3
-    # via jinja2
-ops==2.6.0
+    # via
+    #   -r requirements.txt
+    #   jinja2
+ops==2.12.0
     # via
     #   -r requirements-unit.in
-    #   -r requirements.in
+    #   -r requirements.txt
     #   charmed-kubeflow-chisme
     #   serialized-data-interface
 ordered-set==4.1.0
-    # via deepdiff
+    # via
+    #   -r requirements.txt
+    #   deepdiff
 packaging==23.1
     # via pytest
 pkgutil-resolve-name==1.3.10
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 pluggy==1.3.0
     # via pytest
 pyrsistent==0.19.3
-    # via jsonschema
+    # via
+    #   -r requirements.txt
+    #   jsonschema
 pytest==7.4.0
     # via
     #   -r requirements-unit.in
@@ -79,32 +112,50 @@ pytest-mock==3.11.1
     # via -r requirements-unit.in
 pyyaml==6.0.1
     # via
+    #   -r requirements.txt
     #   lightkube
     #   ops
     #   serialized-data-interface
 requests==2.31.0
-    # via serialized-data-interface
+    # via
+    #   -r requirements.txt
+    #   serialized-data-interface
 ruamel-yaml==0.18.5
-    # via charmed-kubeflow-chisme
+    # via
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.8
-    # via ruamel-yaml
+    # via
+    #   -r requirements.txt
+    #   ruamel-yaml
 serialized-data-interface==0.7.0
     # via
-    #   -r requirements.in
+    #   -r requirements.txt
     #   charmed-kubeflow-chisme
 sniffio==1.3.0
     # via
+    #   -r requirements.txt
     #   anyio
     #   httpx
 tenacity==8.2.3
-    # via charmed-kubeflow-chisme
+    # via
+    #   -r requirements.txt
+    #   charmed-kubeflow-chisme
 tomli==2.0.1
     # via pytest
 typing-extensions==4.9.0
-    # via anyio
+    # via
+    #   -r requirements.txt
+    #   anyio
 urllib3==2.0.4
-    # via requests
+    # via
+    #   -r requirements.txt
+    #   requests
 websocket-client==1.6.2
-    # via ops
+    # via
+    #   -r requirements.txt
+    #   ops
 zipp==3.16.2
-    # via importlib-resources
+    # via
+    #   -r requirements.txt
+    #   importlib-resources

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,7 +46,7 @@ lightkube-models==1.29.0.6
     # via lightkube
 markupsafe==2.1.3
     # via jinja2
-ops==2.6.0
+ops==2.12.0
     # via
     #   -r requirements.in
     #   charmed-kubeflow-chisme


### PR DESCRIPTION
Bumping juju and ops packages to use them in newer versions of the charms, plus testing them in a CI with a more recent juju version.

Part of canonical/bundle-kubeflow#859