### PR TITLE
ci: bump juju 3.1 -> 3.5 in track

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,7 +57,7 @@ jobs:
           channel: 1.25-strict/stable
           microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
           charmcraft-channel: latest/candidate
-          juju-channel: 3.4/stable
+          juju-channel: 3.5/stable
 
       - name: Run test
         run: |


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/859, Part of https://github.com/canonical/bundle-kubeflow/issues/862