### PR TITLE
Update kubeflow-volumes-operator to 2.2.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -16,5 +16,5 @@ options:
     description: Whether cookies should require HTTPS
   volume-viewer-image:
     type: string
-    default: charmedkubeflow/filebrowser:2.27.0-f21fe9d
+    default: filebrowser/filebrowser:v2.25.0
     description: Volume Viewer OCI Image (PVCViewer)

--- a/config.yaml
+++ b/config.yaml
@@ -16,5 +16,5 @@ options:
     description: Whether cookies should require HTTPS
   volume-viewer-image:
     type: string
-    default: filebrowser/filebrowser:v2.25.0
+    default: charmedkubeflow/filebrowser:2.27.0-f21fe9d
     description: Volume Viewer OCI Image (PVCViewer)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/kubeflownotebookswg/volumes-web-app:v1.8.0
+    upstream-source: docker.io/kubeflownotebookswg/volumes-web-app:v1.9.0-rc.0
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-volumes-operator/issues/134

I have compared tags `v1.8.0` and `v1.9.0-rc.0` for these files: https://github.com/kubeflow/kubeflow/tree/master/components/crud-web-apps/volumes

Changes 
- image + filebrowser image

**Note:** Ignoring filebrowser as we already support higher ROCK version