### PR TITLE
chore: bump image to 1.9.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/kubeflownotebookswg/volumes-web-app:v1.9.0-rc.0
+    upstream-source: docker.io/kubeflownotebookswg/volumes-web-app:v1.9.0
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Closes #143 

Compared tags v1.9.0-rc.0 and v1.9.0 after generating manifests with:
```
kustomize build apps/volumes-web-app/upstream/overlays/istio > volumes-v1.9.0-rc-0.yaml
kustomize build apps/volumes-web-app/upstream/overlays/istio > volumes-v1.9.0.yaml
diff volumes-v1.9.0-rc-0.yaml volumes-v1.9.0.yaml > volumes-v1.9.0-rc.0-v1.9.0.diff
```

Changes in `viewer-spec.yaml` were already here for us (not sure why).
