### PR TITLE
Use 1.9.0 rock

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/kubeflownotebookswg/volumes-web-app:v1.9.0
+    upstream-source: docker.io/charmedkubeflow/volumes-web-app:1.9.0-287d9e9
 requires:
   ingress:
     interface: ingress

--- a/src/components/pebble_components.py
+++ b/src/components/pebble_components.py
@@ -28,7 +28,7 @@ class KubeflowVolumesPebbleService(PebbleServiceComponent):
             {
                 "services": {
                     self.service_name: {
-                        "override": "replace",
+                        "override": "merge",
                         "summary": "entry point for kubeflow-volumes",
                         "command": "/bin/bash -c 'gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app'",  # noqa: E501
                         "startup": "enabled",


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-volumes-operator/issues/153

After this we need to backport this changes to track branch for 1.9.