### PR TITLE
chore: upgrade manifests to 1.10.0-rc.0

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       run: sudo apt install tox
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install dependencies
       run: sudo apt install tox
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup operator environment
         uses: charmed-kubernetes/actions-operator@main
@@ -101,21 +101,21 @@ jobs:
         if: failure()
 
       - name: Upload inspect tarball
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: inspection-reports
           path: ./inspection-report-${{ strategy.job-index }}.tar.gz
         if: failure()
 
       - name: Upload selenium screenshots
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: selenium-screenshots
           path: /tmp/selenium-*.png
         if: failure()
 
       - name: Upload HAR logs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: selenium-har
           path: /tmp/selenium-*.har

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with: 
           fetch-depth: 0
           ref: ${{ inputs.source_branch }}
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ inputs.source_branch }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Promote charm
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Release charm to channel
         uses: canonical/charming-actions/release-charm@2.6.2
         with:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/charmedkubeflow/volumes-web-app:1.9.0-287d9e9
+    upstream-source: docker.io/kubeflownotebookswg/volumes-web-app:v1.10.0-rc.0
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Upgrade image according to KF/KF 1.10.0-rc.0 and KF/manifests v1.10.0-rc.1.

Whole manifests diff.
```diff
165a166
>   VWA_APP_ENABLE_METRICS: "1"
176c177
<   name: volumes-web-app-parameters-57h65c44mg
---
>   name: volumes-web-app-parameters-mbftc78hbk
288c289,291
<         image: docker.io/kubeflownotebookswg/volumes-web-app:v1.9.2
---
>         - name: METRICS
>           value: "1"
>         image: docker.io/kubeflownotebookswg/volumes-web-app:v1.10.0-rc.0

```

This is pointed to a dev branch and metrics feature + tests is introduced in a follow-up PR.

Ref https://warthogs.atlassian.net/browse/KF-6846