### PR TITLE
chore: integrate volumes rock 1.10.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,7 +14,7 @@ resources:
   oci-image:
     type: oci-image
     description: 'Backing OCI image'
-    upstream-source: docker.io/charmedkubeflow/volumes-web-app:1.10.0-rc.1-0ce9b4c
+    upstream-source: docker.io/charmedkubeflow/volumes-web-app:1.10.0-a526a2e
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Closes https://warthogs.atlassian.net/browse/KF-7149

The only changes introduced in Kubeflow 1.10.0-rc.3 were image updates, thus we just need to integrate the rocks for version 1.10.0 of the volumes web app according to https://github.com/kubeflow/manifests/pull/3071.