### PR TITLE
chore: pin charm dependencies in tests (track/1.10)

### DIFF
--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -3,11 +3,11 @@
 from charmed_kubeflow_chisme.testing import CharmSpec
 
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="1.24/stable", config={"kind": "ingress"}, trust=True
+    charm="istio-gateway", channel="1.28/stable", config={"kind": "ingress"}, trust=True
 )
 ISTIO_PILOT = CharmSpec(
     charm="istio-pilot",
-    channel="1.24/stable",
+    channel="1.28/stable",
     config={"default-gateway": "kubeflow-gateway"},
     trust=True,
 )

--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -3,13 +3,13 @@
 from charmed_kubeflow_chisme.testing import CharmSpec
 
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="1.28/stable", config={"kind": "ingress"}, trust=True
+    charm="istio-gateway", channel="1.28/edge", config={"kind": "ingress"}, trust=True
 )
 ISTIO_PILOT = CharmSpec(
     charm="istio-pilot",
-    channel="1.28/stable",
+    channel="1.28/edge",
     config={"default-gateway": "kubeflow-gateway"},
     trust=True,
 )
-KUBEFLOW_DASHBOARD = CharmSpec(charm="kubeflow-dashboard", channel="1.10/stable", trust=True)
-KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="1.10/stable", trust=True)
+KUBEFLOW_DASHBOARD = CharmSpec(charm="kubeflow-dashboard", channel="1.10/edge", trust=True)
+KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="1.10/edge", trust=True)


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External (resolved via Terraform Solutions track/1.11)
- `istio-gateway`: `1.24/stable` → `1.28/stable`
- `istio-pilot`: `1.24/stable` → `1.28/stable`

Refs: canonical/bundle-kubeflow#1379
