### PR TITLE
fix: remove MicroK8s inspect from CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -184,20 +184,6 @@ jobs:
         run: kubectl logs --tail 100 -n kubeflow -l app.kubernetes.io/name=kubeflow-volumes -c charm
         if: failure()
 
-      - name: Generate inspect tarball
-        run: >
-          sudo microk8s inspect |
-          grep -Po "Report tarball is at \K.+" |
-          sudo xargs -I {} mv {} inspection-report-${{ strategy.job-index }}.tar.gz
-        if: failure()
-
-      - name: Upload inspect tarball
-        uses: actions/upload-artifact@v4
-        with:
-          name: inspection-reports
-          path: ./inspection-report-${{ strategy.job-index }}.tar.gz
-        if: failure()
-
       - name: Upload selenium screenshots
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,6 +194,6 @@ jobs:
       - name: Upload HAR logs
         uses: actions/upload-artifact@v4
         with:
-          name: selenium-har
+          name: selenium-har-${{ matrix.test-type }}
           path: /tmp/selenium-*.har
         if: failure()

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,7 +187,7 @@ jobs:
       - name: Upload selenium screenshots
         uses: actions/upload-artifact@v4
         with:
-          name: selenium-screenshots
+          name: selenium-screenshots-${{ matrix.test-type }}
           path: /tmp/selenium-*.png
         if: failure()
 


### PR DESCRIPTION
## Summary
This PR removes the MicroK8s inspect tarball generation and upload steps from CI failure diagnostics.


Fixes review comment: https://github.com/canonical/kubeflow-volumes-operator/pull/252#discussion_r3348399791