### PR TITLE
fix: handle multiple `istio-ingress-route` relations

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -13,7 +13,7 @@ providers:
       load-balancer:
         enabled: true
         l2-mode: true
-        cidrs: 10.64.140.43/32
+        cidrs: 10.64.140.42/31  # NOTE: at least two IPs required for integration tests: one for each of the two Istio ingress gateways
     bootstrap-constraints:
       root-disk: 2G
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3953,4 +3953,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "dbe9748b6c95c43e9f0d9597231113480e39d2f40cfa44db348606edd001e135"
+content-hash = "70b8087ec7d12afe79073e1c11a4249cf87f4b6249c2ed7e9d0bba03250b8c7e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ pytest-operator = "^0.38.0"
 pyyaml = "^6.0.2"
 selenium = "^4.27.1"
 selenium-wire = "^5.1.0"
+tenacity = "^9.0.0"
 
 [project]
 name = "kubeflow-volumes-operator"

--- a/src/components/istio_relations_conflict_detector.py
+++ b/src/components/istio_relations_conflict_detector.py
@@ -21,11 +21,15 @@ class IstioRelationsConflictDetectorComponent(Component):
         self.ambient_relation_name = ambient_relation_name
 
     def get_status(self) -> StatusBase:
-        """Check that both ambient and sidecar relations are not present simultaneously."""
-        ambient_relation = self._charm.model.get_relation(self.ambient_relation_name)
-        sidecar_relation = self._charm.model.get_relation(self.sidecar_relation_name)
+        """Check that both ambient and sidecar relations are not present simultaneously.
 
-        if ambient_relation and sidecar_relation:
+        Each endpoint may hold any number of relations, so this inspects the full list
+        of relations on each endpoint rather than assuming at most one.
+        """
+        ambient_relations = self._charm.model.relations[self.ambient_relation_name]
+        sidecar_relations = self._charm.model.relations[self.sidecar_relation_name]
+
+        if ambient_relations and sidecar_relations:
             logger.error(
                 f"Both '{self.ambient_relation_name}' and '{self.sidecar_relation_name}' "
                 "relations are present, remove one to unblock."

--- a/tests/integration/test_charm_ambient.py
+++ b/tests/integration/test_charm_ambient.py
@@ -5,8 +5,11 @@ import logging
 from pathlib import Path
 
 import pytest
+import tenacity
 import yaml
 from charmed_kubeflow_chisme.testing import (
+    ISTIO_INGRESS_K8S_APP,
+    ISTIO_INGRESS_ROUTE_ENDPOINT,
     assert_logging,
     assert_path_reachable_through_ingress,
     deploy_and_assert_grafana_agent,
@@ -14,6 +17,8 @@ from charmed_kubeflow_chisme.testing import (
     integrate_with_service_mesh,
 )
 from charms_dependencies import KUBEFLOW_DASHBOARD, KUBEFLOW_PROFILES
+from lightkube import Client
+from lightkube.generic_resource import create_namespaced_resource
 from pytest_operator.plugin import OpsTest
 
 log = logging.getLogger(__name__)
@@ -25,6 +30,34 @@ HEADERS = {
     "kubeflow-userid": "",
 }
 HTTP_PATH = "/volumes"
+
+# A second istio-ingress-k8s instance used to verify multiple-ingress support.
+SECOND_INGRESS_APP = "istio-ingress-k8s-alt"
+INGRESS_CHANNEL = "2/stable"
+# Name of the HTTPRoute submitted by kubeflow-volumes (see AmbientIngressRequirerComponent).
+INGRESS_ROUTE_NAME = "http-route"
+# Gateway listener section for cleartext HTTP on port 80.
+HTTP_SECTION_NAME = "http-80"
+# Path matched by the kubeflow-volumes HTTPRoute.
+INGRESS_ROUTE_PATH = HTTP_PATH
+# Gateway API generic resources, resolved at runtime via lightkube.
+HTTPROUTE_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "HTTPRoute", "httproutes"
+)
+GATEWAY_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "Gateway", "gateways"
+)
+RETRY_120_SECONDS = tenacity.Retrying(
+    stop=tenacity.stop_after_delay(120),
+    wait=tenacity.wait_fixed(2),
+    reraise=True,
+)
+
+
+@pytest.fixture(scope="session")
+def lightkube_client() -> Client:
+    client = Client(field_manager=CHARM_NAME)
+    return client
 
 
 @pytest.mark.abort_on_fail
@@ -94,8 +127,7 @@ async def test_logging(ops_test: OpsTest):
     await assert_logging(app)
 
 
-@pytest.mark.abort_on_fail
-async def test_ui_is_accessible(ops_test: OpsTest):
+async def assert_ui_is_accessible(ops_test: OpsTest):
     """Verify that UI is accessible through the ingress gateway."""
     await assert_path_reachable_through_ingress(
         http_path=HTTP_PATH,
@@ -103,3 +135,90 @@ async def test_ui_is_accessible(ops_test: OpsTest):
         headers=HEADERS,
         expected_content_type="text/html",
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_ui_is_accessible(ops_test: OpsTest):
+    """Verify that UI is accessible through the ingress gateway before the second ingress."""
+    await assert_ui_is_accessible(ops_test)
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_and_relate_second_ingress(ops_test: OpsTest):
+    """Deploy a second istio-ingress-k8s and relate it to kubeflow-volumes.
+
+    kubeflow-volumes must accept more than one istio-ingress-route relation without
+    erroring, so it should remain active after the second ingress is related.
+    """
+    await ops_test.model.deploy(
+        ISTIO_INGRESS_K8S_APP,
+        application_name=SECOND_INGRESS_APP,
+        channel=INGRESS_CHANNEL,
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(
+        [SECOND_INGRESS_APP],
+        raise_on_blocked=False,
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=60 * 15,
+    )
+
+    await ops_test.model.integrate(
+        f"{SECOND_INGRESS_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+        f"{CHARM_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+    )
+    await ops_test.model.wait_for_idle(
+        [CHARM_NAME, SECOND_INGRESS_APP],
+        status="active",
+        raise_on_blocked=False,
+        raise_on_error=False,
+        timeout=60 * 10,
+        idle_period=30,
+    )
+
+    assert ops_test.model.applications[CHARM_NAME].units[0].workload_status == "active"
+
+
+async def test_httproute_attached_to_second_gateway(ops_test: OpsTest, lightkube_client: Client):
+    """Verify the HTTPRoute for the second ingress is created and bound to its Gateway.
+
+    The istio-ingress-k8s charm names each route
+    ``{source_app}-{route_name}-httproute-{section}-{ingress_app}`` and binds it to a
+    Gateway named after the ingress application via ``parentRefs``. We assert that the
+    route created for the second ingress is attached to the *second* Gateway (not the
+    first) and routes the kubeflow-volumes path to the kubeflow-volumes backend.
+    """
+    namespace = ops_test.model.name
+
+    expected_route_name = (
+        f"{CHARM_NAME}-{INGRESS_ROUTE_NAME}-httproute-{HTTP_SECTION_NAME}-{SECOND_INGRESS_APP}"
+    )
+
+    # The second Gateway should exist, named after the second ingress application.
+    lightkube_client.get(GATEWAY_RESOURCE, name=SECOND_INGRESS_APP, namespace=namespace)
+
+    # Retry to give the ingress charm time to reconcile the HTTPRoute resources.
+    httproute = None
+    for attempt in RETRY_120_SECONDS:
+        with attempt:
+            httproute = lightkube_client.get(
+                HTTPROUTE_RESOURCE, name=expected_route_name, namespace=namespace
+            )
+
+    parent_refs = httproute.spec["parentRefs"]
+    assert len(parent_refs) == 1
+    # The route must be attached to the SECOND gateway, not the first.
+    assert parent_refs[0]["name"] == SECOND_INGRESS_APP
+    assert parent_refs[0]["sectionName"] == HTTP_SECTION_NAME
+
+    # And it must route the kubeflow-volumes path to the kubeflow-volumes backend.
+    rule = httproute.spec["rules"][0]
+    assert rule["matches"][0]["path"]["value"] == INGRESS_ROUTE_PATH
+    assert rule["backendRefs"][0]["name"] == CHARM_NAME
+
+
+@pytest.mark.abort_on_fail
+async def test_ui_is_accessible_after_second_ingress(ops_test: OpsTest):
+    """Verify that UI is still accessible through the ingress gateway after the second ingress."""
+    await assert_ui_is_accessible(ops_test)

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -341,3 +341,22 @@ def test_istio_relations_conflict_detector_both_relations(
     assert "Cannot have both" in status.message
     assert "istio-ingress-route" in status.message
     assert "ingress" in status.message
+
+
+def test_istio_relations_conflict_detector_multiple_ambient_relations(
+    harness,
+    mocked_lightkube_client,
+    mocked_kubernetes_service_patch,
+    mocked_istio_ingress_requirer,
+):
+    """Test conflict detector handles multiple istio-ingress-route relations without erroring."""
+    # Arrange
+    harness.begin()
+
+    # Act - Add more than one relation on the ambient ingress endpoint
+    harness.add_relation("istio-ingress-route", "istio-ingress")
+    harness.add_relation("istio-ingress-route", "istio-ingress-2")
+
+    # Assert - inspecting the full list of relations per endpoint must not raise
+    status = harness.charm.istio_relations_conflict_detector.component.get_status()
+    assert isinstance(status, ActiveStatus)

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -5,7 +5,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 from charmed_kubeflow_chisme.testing import add_sdi_relation_to_harness
-from charms.istio_ingress_k8s.v0.istio_ingress_route import ProtocolType
+from charms.istio_ingress_k8s.v0.istio_ingress_route import (
+    HTTPPathMatchType,
+    IstioIngressRouteConfig,
+    ProtocolType,
+)
 from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 
@@ -360,3 +364,42 @@ def test_istio_relations_conflict_detector_multiple_ambient_relations(
     # Assert - inspecting the full list of relations per endpoint must not raise
     status = harness.charm.istio_relations_conflict_detector.component.get_status()
     assert isinstance(status, ActiveStatus)
+
+
+def test_each_istio_ingress_route_relation_receives_config(
+    harness,
+    mocked_lightkube_client,
+    mocked_kubernetes_service_patch,
+):
+    """Test that an HTTPRoute config is submitted to every istio-ingress-route relation."""
+    # Arrange (note: the real IstioIngressRouteRequirer is used here, not the mock,
+    # so we can assert on the config it writes to each relation databag).
+    harness.begin()
+
+    rel_id_1 = harness.add_relation("istio-ingress-route", "istio-ingress")
+    rel_id_2 = harness.add_relation("istio-ingress-route", "istio-ingress-2")
+
+    # Only force readiness so the real submit_config writes to the databags.
+    ingress = harness.charm.ambient_ingress_relation.component.ingress
+    ingress.is_ready = MagicMock(return_value=True)
+
+    # Act - reconcile the charm so the component submits its config.
+    harness.charm.on.install.emit()
+
+    # Assert
+    # Each relation's application databag should contain a valid config that
+    # defines the kubeflow-volumes HTTPRoute, proving the lib handles every ingress.
+    for rel_id in (rel_id_1, rel_id_2):
+        app_data = harness.get_relation_data(rel_id, harness.charm.app.name)
+        assert "config" in app_data
+
+        config = IstioIngressRouteConfig.model_validate_json(app_data["config"])
+        assert len(config.http_routes) == 1
+        http_route = config.http_routes[0]
+        assert http_route.matches[0].path.type == HTTPPathMatchType.PathPrefix
+        assert http_route.matches[0].path.value == "/volumes"
+        assert http_route.backends[0].service == harness.charm.app.name
+        assert http_route.backends[0].port == int(harness.charm.model.config["port"])
+        # The route's parent (the Gateway listener referenced under parentRefs in
+        # the HTTPRouteSpec) should be the expected HTTP listener.
+        assert http_route.listener.name == "http-80"


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/1446

Use `model.relations[...]` instead of `model.get_relation(...)` when checking ingress relations, so the charm no longer raises `TooManyRelatedAppsError` when more than one `istio-ingress-route` relation is present.

Add unit tests covering multiple `istio-ingress-route` relations and verifying each relation receives a valid `HTTPRoute` config.

_Note: this PR was created with the help of AI_